### PR TITLE
Update: Sidekiq version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ DECIDIM_VERSION = '0.15.2'
 
 gem 'rails', '5.2.1'
 gem 'decidim', DECIDIM_VERSION
-gem 'sidekiq'
+gem 'sidekiq', '5.2.7'
 
 gem 'puma'
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,11 +631,11 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sidekiq (6.0.2)
-      connection_pool (>= 2.2.2)
-      rack (>= 2.0.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -723,7 +723,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (= 5.2.1)
-  sidekiq
+  sidekiq (= 5.2.7)
   spring
   spring-watcher-listen
   sprockets (~> 3.7.2)


### PR DESCRIPTION
- Lock `sidekiq` version to work with current deploy setup