### PR TITLE
Configure SSL 

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -23,7 +23,7 @@ Decidim.configure do |config|
   config.currency_unit = "€"
 
   # SSL disabled
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Enable HTML header snippets
   config.enable_html_header_snippets = true

--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -5,6 +5,7 @@ services:
     image: vilanovailageltru/decidim-vilanova:latest
     ports:
       - 80:80
+      - 443:443
     volumes:
       - /opt/decidim-vilanova/uploads:/home/app/decidim-vilanova/public/uploads
       - /opt/decidim-vilanova/storage:/home/app/decidim-vilanova/storage

--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -9,6 +9,7 @@ services:
       - /opt/decidim-vilanova/uploads:/home/app/decidim-vilanova/public/uploads
       - /opt/decidim-vilanova/storage:/home/app/decidim-vilanova/storage
       - /opt/decidim-vilanova/log:/home/app/decidim-vilanova/log
+      - /opt/decidim-vilanova/certs:/home/app/decidim-vilanova/certs
     deploy:
       replicas: 1
       update_config:
@@ -28,6 +29,7 @@ services:
       - /opt/decidim-vilanova/uploads:/home/app/decidim-vilanova/public/uploads
       - /opt/decidim-vilanova/storage:/home/app/decidim-vilanova/storage
       - /opt/decidim-vilanova/log:/home/app/decidim-vilanova/log
+      - /opt/decidim-vilanova/certs:/home/app/decidim-vilanova/certs
     deploy:
       replicas: 1
       update_config:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,10 +1,35 @@
 server {
-  listen 80 default_server;
+  listen        80;
+  server_name participa.vilanova.cat;
+  return        301 https://{{site_host}}$request_uri;
+}
+
+server {
+  listen      443 ssl http2 default_server;
+  listen   [::]:443 ssl http2;
+
+  server_name participa.vilanova.cat;
+
+  ## [SSL Config]
+  ssl_certificate /home/app/decidim-vilanova/certs/vilanova.crt;
+  ssl_certificate_key /home/app/decidim-vilanova/certs/vilanova.key;
+
+  ssl_protocols TLSv1.3 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA512:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:ECDH+AESGCM:ECDH+AES256:DH+AESGCM:DH+AES256:RSA+AESGCM:!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS;
+  ssl_session_cache shared:TLS:2m;
+  ssl_buffer_size 1k;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001]; # Cloudflare
+  # Set HSTS to 365 days
+  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
+  ## [./ SSL Config]
+
   root /home/app/decidim-vilanova/public;
   passenger_enabled on;
   passenger_user app;
   passenger_ruby /usr/bin/ruby2.7;
-  server_name participa.vilanova.cat;
 
   passenger_min_instances ${PASSENGER_MIN_INSTANCES};
 
@@ -14,6 +39,14 @@ server {
     add_header ETag "";
     break;
   }
+
+  location ~ ^/packs/ {
+    expires 1y;
+    add_header Cache-Control public;
+    add_header ETag "";
+    break;
+  }
+
 
   location ~ ^/uploads/ {
     expires 24h;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,14 +1,11 @@
 server {
-  listen        80;
-  server_name participa.vilanova.cat;
-  return        301 https://{{site_host}}$request_uri;
+  listen        80 default_server;
+  return  301 https://$host$request_uri;
 }
 
 server {
   listen      443 ssl http2 default_server;
   listen   [::]:443 ssl http2;
-
-  server_name participa.vilanova.cat;
 
   ## [SSL Config]
   ssl_certificate /home/app/decidim-vilanova/certs/vilanova.crt;
@@ -31,7 +28,7 @@ server {
   passenger_user app;
   passenger_ruby /usr/bin/ruby2.7;
 
-  passenger_min_instances ${PASSENGER_MIN_INSTANCES};
+  passenger_min_instances 2;
 
   location ~ ^/assets/ {
     expires 1y;
@@ -62,5 +59,5 @@ server {
   rewrite ^/accessibility$  /pages/accessibility redirect;
 }
 
-passenger_max_pool_size ${PASSENGER_MAX_POOL_SIZE};
+passenger_max_pool_size 8;
 passenger_pre_start http://participa.vilanova.cat;


### PR DESCRIPTION
This PR:

- updates Nginx configuration to redirect all the traffic to 443 port
- forces Decidim to work on SSL mode

Docker tag: vilanovailageltru/decidim-vilanova:0.26.2-20220903