### PR TITLE
Add task to export emails of users with proposals by process

### DIFF
--- a/lib/tasks/export_proposals_users.rake
+++ b/lib/tasks/export_proposals_users.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+include Decidim::TranslatableAttributes
+
+namespace :decidim_vilanova do
+
+  desc "Export emails of users which created a proposal by participatory process"
+  task export_proposals_users: :environment do
+    processes = Decidim::ParticipatoryProcess.all
+
+    processes.each do |process|
+      path = "tmp/process_#{process.slug}.csv"
+      puts "=== Exporting data of process #{translated_attribute(process.title)} with slug #{process.slug} to #{path}..."
+
+      CSV.open(path, "wb") do |csv|
+        components = process.components.where(manifest_name: "proposals")
+        proposals = Decidim::Proposals::Proposal.where(component: components)
+        emails = proposals.map(&:authors).flatten.uniq.map { |author| author.try(:email) }.compact
+        csv << ['email']
+        emails.each { |email| csv << [email] }
+      end
+    end
+  end
+end

--- a/lib/tasks/export_proposals_users.rake
+++ b/lib/tasks/export_proposals_users.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-include Decidim::TranslatableAttributes
-
 namespace :decidim_vilanova do
 
   desc "Export emails of users which created a proposal by participatory process"
@@ -10,7 +8,7 @@ namespace :decidim_vilanova do
 
     processes.each do |process|
       path = "tmp/process_#{process.slug}.csv"
-      puts "=== Exporting data of process #{translated_attribute(process.title)} with slug #{process.slug} to #{path}..."
+      puts "=== Exporting data of process #{process.title.values.compact_blank.first} with slug #{process.slug} to #{path}..."
 
       CSV.open(path, "wb") do |csv|
         components = process.components.where(manifest_name: "proposals")


### PR DESCRIPTION
closes PopulateTools/issues#1782

This PR adds a task to generate a csv file by process and export the emails of different users which has authored or coauthored a proposal inside the process

Just run:
```
rails decidim_vilanova:export_proposals_users
```

And the files will be generated in tmp/ with name process_#{slug}.csv